### PR TITLE
Add babel-plugin-polished to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "@babel/core": "^7.0.0",
     "babel-preset-gatsby-package": "^0.1.2"
   },
+  "peerDependencies": {
+    "babel-plugin-polished": "^1.0.0"
+  },
   "bugs": {
     "url": "https://github.com/Corjen/gatsby-plugin-polished/issues"
   },


### PR DESCRIPTION
just so `yarn` can complain before even running `gatsby` (:

thanks for this plugin, also, just discovered `babel-plugin-polished`.